### PR TITLE
Update to 6.36, add several event and monster commands, minor fixes to charsets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>dom6utils</groupId>
+	<artifactId>dom6utils</artifactId>
+	<version>6.36-SNAPSHOT</version>
+
+	<properties>
+		<maven.compiler.release>8</maven.compiler.release>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi-ooxml</artifactId>
+			<version>5.2.3</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.22.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.22.1</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<sourceDirectory>src</sourceDirectory>
+	</build>
+</project>

--- a/src/dom6utils/AbstractStatIndexer.java
+++ b/src/dom6utils/AbstractStatIndexer.java
@@ -32,7 +32,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public abstract class AbstractStatIndexer {
-	protected static String EXE_NAME = "Dominions6.exe";
+	protected static final String EXE_NAME = System.getenv().getOrDefault("DOM6_EXE", "Dominions6.exe");
 	
 	private static int MASK[] = {0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080,
 			0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000, 0x8000};

--- a/src/dom6utils/CSVWriter.java
+++ b/src/dom6utils/CSVWriter.java
@@ -16,10 +16,12 @@ package dom6utils;
 */
 import java.io.BufferedWriter;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
+import java.io.OutputStreamWriter;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.Locale;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.DataFormatter;
@@ -64,7 +66,9 @@ public class CSVWriter {
 	
 	public static BufferedWriter getBFW (String basename, SSType ssType) throws IOException {
 		if (basename != null && !basename.isEmpty()) {
-			return new BufferedWriter(new FileWriter(CSVWriter.getFilePathWithExtension(basename, ssType)));
+			return new BufferedWriter(new OutputStreamWriter(
+					new FileOutputStream(CSVWriter.getFilePathWithExtension(basename, ssType)),
+					StandardCharsets.ISO_8859_1));
 		}
 		return null;
 	}
@@ -81,7 +85,8 @@ public class CSVWriter {
 				columnsInWidestRow = Math.max(columnsInWidestRow, curRow.getLastCellNum());
 			}
 			
-			DataFormatter df = new DataFormatter(true);
+			// Locale-independent number rendering
+			DataFormatter df = new DataFormatter(Locale.US, true);
 			for (Row curRow : sheet) {
 				if (curRow != null) {
 					boolean firstColumn = true;
@@ -97,7 +102,7 @@ public class CSVWriter {
 						}
 						
 						if (curCell != null) {
-							writer.write(df.formatCellValue(curCell));
+							writer.write(utf8Safe(df.formatCellValue(curCell)));
 						}
 					}
 				}
@@ -107,6 +112,25 @@ public class CSVWriter {
 		}
 	}
 	
+	/**
+	 * Cell text arrives as one char per exe byte (every indexer reads the exe as
+	 * ISO-8859-1) and the CSV writer emits it as ISO-8859-1, so UTF-8 strings in the
+	 * exe round-trip byte for byte. A few strings (the fixed names) are stored as
+	 * Latin-1 in the exe; those would come out as invalid UTF-8, so we re-encode them.
+	 */
+	private static String utf8Safe(String s) {
+		byte[] raw = s.getBytes(StandardCharsets.ISO_8859_1);
+		try {
+			StandardCharsets.UTF_8.newDecoder()
+				.onMalformedInput(java.nio.charset.CodingErrorAction.REPORT)
+				.onUnmappableCharacter(java.nio.charset.CodingErrorAction.REPORT)
+				.decode(java.nio.ByteBuffer.wrap(raw));
+			return s;
+		} catch (java.nio.charset.CharacterCodingException e) {
+			return new String(s.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
+		}
+	}
+
 	private static char getDelimeterChar(Delimiter delim) {
 		switch (delim) {
 		case COMMA:

--- a/src/dom6utils/EventStatIndexer.java
+++ b/src/dom6utils/EventStatIndexer.java
@@ -187,6 +187,55 @@ public class EventStatIndexer extends AbstractStatIndexer {
 		{"5400", "noench"},
 		{"5600", "permonth"},
 		{"5a00", "enchdom"},
+		{"0601", "targseductions"},
+		{"1200", "nation"},
+		{"4700", "indepok"},
+		{"4B00", "nopathwater"},
+		{"5200", "nopathholy"},
+		{"5C00", "notcode"},
+		{"5F00", "enchtarget"},
+		{"6000", "unclaimedthronesite"},
+		{"6100", "mnr"},
+		{"6200", "2monsters"},
+		{"6300", "cataclysmturn"},
+		{"6500", "month"},
+		{"6600", "5monsters"},
+		{"6800", "notanycode"},
+		{"6900", "deadmnr"},
+		{"7200", "playerturn"},
+		{"7300", "unitrecruit"},
+		{"7500", "godalive"},
+		{"7600", "worldunitrare"},
+		{"7700", "godismnr"},
+		{"7F00", "ench"},
+		{"8000", "noench"},
+		{"8100", "maxturn"},
+		{"8500", "orpathearth"},
+		{"8900", "orpathglamour"},
+		{"8C00", "default"},
+		{"9600", "rare"},
+		{"9800", "luckrare"},
+		{"9900", "turnrare"},
+		{"9B00", "dominionrare"},
+		{"9C00", "voidok"},
+		{"9D00", "void"},
+		{"AD00", "forestcave"},
+		{"AF00", "drip"},
+		{"B000", "minglobals"},
+		{"BA00", "mnrbs"},
+		{"BB00", "monsterbs"},
+		{"E000", "targpath3"},
+		{"E300", "targhumanoid"},
+		{"E400", "targmale"},
+		{"E500", "targaff"},
+		{"E700", "targsneaking"},
+		{"E800", "targmanygems"},
+		{"E900", "targsight"},
+		{"EA00", "targundead"},
+		{"EB00", "targdemon"},
+		{"EF00", "targimmobile"},
+		{"F400", "targfreeitemslot"},
+		{"F600", "targmaxmorale"},
 
 	};
 	
@@ -249,7 +298,7 @@ public class EventStatIndexer extends AbstractStatIndexer {
 		{"2E00", "gemloss"}, 
 		{"2F00", "gemloss"}, 
 		{"3000", "gemloss"}, 
-		{"0300", "e3"}, 
+		{"0300", "assfollower1"},
 		{"3F00", "killmon"}, 
 		{"4400", "killcom"}, 
 		{"5300", "fireboost"}, 
@@ -301,6 +350,62 @@ public class EventStatIndexer extends AbstractStatIndexer {
 		{"7100", "notext"}, 
 		{"6A00", "pathboost"}, 
 		{"6C00", "gainaff"}, 
+		{"0400", "assfollower2"},
+		{"0600", "assfollower1d3"},
+		{"0700", "killpop"},
+		{"1400", "allvis"},
+		{"2700", "assassinationbattle"},
+		{"2A00", "gold"},
+		{"3100", "gemloss1d6"},
+		{"4200", "hiddensite"},
+		{"5E00", "code2"},
+		{"6B00", "flagland"},
+		{"6E00", "delay"},
+		{"6F00", "delay25"},
+		{"7000", "delay50"},
+		{"7300", "purgecalendar"},
+		{"7400", "purgedelayed"},
+		{"7500", "gainmark"},
+		{"7700", "tempunits"},
+		{"7900", "removesite"},
+		{"8000", "cleartarg"},
+		{"8100", "claimthrone"},
+		{"8200", "poison"},
+		{"8300", "addkills"},
+		{"8400", "kill2d6mon"},
+		{"8500", "arena"},
+		{"8600", "arena2"},
+		{"8700", "resolvearena1"},
+		{"8800", "resolvearena2"},
+		{"8900", "delayskip"},
+		{"8A00", "extramsg"},
+		{"8C00", "eventnation"},
+		{"8D00", "codedelay"},
+		{"8F00", "resetcodedelay"},
+		{"9000", "resetcodedelay2"},
+		{"9100", "worldstorm"},
+		{"9300", "setpoptype"},
+		{"9A00", "bodyguard"},
+		{"9B00", "1unit"},
+		{"9C00", "1d3units"},
+		{"9E00", "3d3units"},
+		{"9F00", "4d3units"},
+		{"A100", "2d6units"},
+		{"A300", "4d6units"},
+		{"A400", "5d6units"},
+		{"A600", "7d6units"},
+		{"A700", "8d6units"},
+		{"A900", "10d6units"},
+		{"AB00", "12d6units"},
+		{"B300", "20d6units"},
+		{"BF00", "globslots"},
+		{"C100", "nextchance"},
+		{"C200", "sinkprovince"},
+		{"C300", "addgeo"},
+		{"CA00", "maybeaddsite"},
+		{"D100", "addseductions"},
+		{"D500", "dispglobals"},
+		{"D700", "maybehiddensite"},
 
 	};
 	
@@ -377,7 +482,7 @@ public class EventStatIndexer extends AbstractStatIndexer {
 
 	private static String translateRequirements(String value) {
 		for (String[]pair : requirementMapping) {
-			if (pair[0].equals(value)) {
+			if (pair[0].equalsIgnoreCase(value)) {
 				return pair[1];
 			}
 		}
@@ -386,7 +491,7 @@ public class EventStatIndexer extends AbstractStatIndexer {
 	
 	private static String translateEffects(String value) {
 		for (String[]pair : effectMapping) {
-			if (pair[0].equals(value)) {
+			if (pair[0].equalsIgnoreCase(value)) {
 				return pair[1];
 			}
 		}
@@ -441,7 +546,7 @@ public class EventStatIndexer extends AbstractStatIndexer {
 
 	        List<Event> events = new ArrayList<Event>();
 
-			stream = new FileInputStream("Dominions6.exe");			
+			stream = new FileInputStream(EXE_NAME);			
 			stream.skip(Starts.EVENT);
 			long startIndex = Starts.EVENT;
 				
@@ -492,7 +597,7 @@ public class EventStatIndexer extends AbstractStatIndexer {
 				
 				events.add(event);
 
-				stream = new FileInputStream("Dominions6.exe");		
+				stream = new FileInputStream(EXE_NAME);		
 				startIndex = startIndex + Starts.EVENT_SIZE;
 				stream.skip(startIndex);
 				isr = new InputStreamReader(stream, "ISO-8859-1");

--- a/src/dom6utils/IndexDumper.java
+++ b/src/dom6utils/IndexDumper.java
@@ -41,7 +41,7 @@ public class IndexDumper {
 		
 		FileInputStream stream = null;
 		try {
-			stream = new FileInputStream("Dominions6.exe");
+			stream = new FileInputStream(AbstractStatIndexer.EXE_NAME);
 			stream.skip(Starts.ITEM_AND_MONSTER_DESC_INDEX);
 
 			List<Long> indexes = new ArrayList<Long>();
@@ -81,11 +81,11 @@ public class IndexDumper {
 			byte[] b = new byte[1];
 			for (Long offset : indexes) {
 				StringBuffer buffer = new StringBuffer();
-				stream = new FileInputStream("Dominions6.exe");
+				stream = new FileInputStream(AbstractStatIndexer.EXE_NAME);
 				stream.skip(offset-Starts.DESC_OFFSET);
 				while (stream.read(b) != -1) {
 					if (b[0] != 0) {
-						buffer.append(new String(new byte[] {b[0]}));
+						buffer.append(new String(new byte[] {b[0]}, java.nio.charset.StandardCharsets.ISO_8859_1));
 					} else {
 						break;
 					}

--- a/src/dom6utils/ItemMonsterDescDumper.java
+++ b/src/dom6utils/ItemMonsterDescDumper.java
@@ -50,7 +50,7 @@ public class ItemMonsterDescDumper {
 			byte[] b34 = new byte[34];
 			byte[] c = new byte[2];
 
-			stream = new FileInputStream("Dominions6.exe");
+			stream = new FileInputStream(AbstractStatIndexer.EXE_NAME);
 			stream.skip(Starts.MONSTER);
 			int id = 1;
 			while (stream.read(b34, 0, 34) != -1) {
@@ -60,7 +60,7 @@ public class ItemMonsterDescDumper {
 				StringBuffer name = new StringBuffer();
 				for (int i = 0; i < 34; i++) {
 					if (b34[i] != 0) {
-						name.append(new String(new byte[] {b34[i]}));
+						name.append(new String(new byte[] {b34[i]}, java.nio.charset.StandardCharsets.ISO_8859_1));
 					}
 				}
 				if (name.toString().equals("end")) {
@@ -72,7 +72,7 @@ public class ItemMonsterDescDumper {
 			}
 			stream.close();
 			
-			stream = new FileInputStream("Dominions6.exe");
+			stream = new FileInputStream(AbstractStatIndexer.EXE_NAME);
 			stream.skip(Starts.ITEM_AND_MONSTER_DESC_INDEX);
 
 			List<Long> indexes = new ArrayList<Long>();
@@ -108,11 +108,11 @@ public class ItemMonsterDescDumper {
 
 			for (Long offset : indexes) {
 				StringBuffer buffer = new StringBuffer();
-				stream = new FileInputStream("Dominions6.exe");
+				stream = new FileInputStream(AbstractStatIndexer.EXE_NAME);
 				stream.skip(offset-Starts.DESC_OFFSET);
 				while (stream.read(b) != -1) {
 					if (b[0] != 0) {
-						buffer.append(new String(new byte[] {b[0]}));
+						buffer.append(new String(new byte[] {b[0]}, java.nio.charset.StandardCharsets.ISO_8859_1));
 					} else {
 						break;
 					}
@@ -135,7 +135,7 @@ public class ItemMonsterDescDumper {
 						if (state == State.ITEM) {
 							Path path = Paths.get("items", "desc", name.replaceAll("[^a-zA-Z0-9\\-]", "") + ".txt");
 							OutputStream os = Files.newOutputStream(path);
-							os.write(desc.getBytes());
+							os.write(desc.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1));
 							os.close();
 							if (name.equals(LAST_ITEM)) {
 								state = State.NOTHING;
@@ -162,7 +162,7 @@ public class ItemMonsterDescDumper {
 							for (Integer idInt : idsInt) {
 								Path path = Paths.get("monsters", "desc", String.format("%04d", idInt) + ".txt");
 								OutputStream os = Files.newOutputStream(path);
-								os.write(desc.getBytes());
+								os.write(desc.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1));
 								os.close();
 							}
 							if (name.equals(LAST_UNIT)) {

--- a/src/dom6utils/ItemSpriteIndexer.java
+++ b/src/dom6utils/ItemSpriteIndexer.java
@@ -82,7 +82,7 @@ public class ItemSpriteIndexer {
 				byte[] b = new byte[1];
 				while (stream.read(b) != -1) {
 					if (b[0] != 0) {
-						buffer.append(new String(new byte[] {b[0]}));
+						buffer.append(new String(new byte[] {b[0]}, java.nio.charset.StandardCharsets.ISO_8859_1));
 					} else {
 						break;
 					}
@@ -97,7 +97,7 @@ public class ItemSpriteIndexer {
 			}
 			
 			Map<String, List<String>> map = new HashMap<String, List<String>>();
-			stream = new FileInputStream("Dominions6.exe");
+			stream = new FileInputStream(AbstractStatIndexer.EXE_NAME);
 
 			byte[] b = new byte[32];
 			byte[] c = new byte[2];
@@ -112,7 +112,7 @@ public class ItemSpriteIndexer {
 				StringBuffer name = new StringBuffer();
 				for (int i = 0; i < 32; i++) {
 					if (b[i] != 0) {
-						name.append(new String(new byte[] {b[i]}));
+						name.append(new String(new byte[] {b[i]}, java.nio.charset.StandardCharsets.ISO_8859_1));
 					}
 				}
 				if (name.toString().equals("end")) {

--- a/src/dom6utils/MonsterSpriteIndexer.java
+++ b/src/dom6utils/MonsterSpriteIndexer.java
@@ -204,7 +204,7 @@ public class MonsterSpriteIndexer extends AbstractStatIndexer {
 				byte[] b = new byte[1];
 				while (stream.read(b) != -1) {
 					if (b[0] != 0) {
-						buffer.append(new String(new byte[] {b[0]}));
+						buffer.append(new String(new byte[] {b[0]}, java.nio.charset.StandardCharsets.ISO_8859_1));
 					} else {
 						break;
 					}
@@ -219,7 +219,7 @@ public class MonsterSpriteIndexer extends AbstractStatIndexer {
 			}
 
 			Map<String, List<String>> map = new HashMap<String, List<String>>();
-			stream = new FileInputStream("Dominions6.exe");
+			stream = new FileInputStream(EXE_NAME);
 
 			byte[] b = new byte[32];
 			byte[] c = new byte[2];
@@ -235,7 +235,7 @@ public class MonsterSpriteIndexer extends AbstractStatIndexer {
 				StringBuffer name = new StringBuffer();
 				for (int i = 0; i < 32; i++) {
 					if (b[i] != 0) {
-						name.append(new String(new byte[] {b[i]}));
+						name.append(new String(new byte[] {b[i]}, java.nio.charset.StandardCharsets.ISO_8859_1));
 					}
 				}
 				if (name.toString().equals("end")) {

--- a/src/dom6utils/MonsterStatIndexer.java
+++ b/src/dom6utils/MonsterStatIndexer.java
@@ -43,7 +43,7 @@ import dom6utils.CSVWriter.SSType;
 public class MonsterStatIndexer extends AbstractStatIndexer {
 	public static String[] unit_columns = {"id", "name", "wpn1", "wpn2", "wpn3", "wpn4", "wpn5", "wpn6", "wpn7", "armor1", "armor2", "armor3", "armor4", 
 			"rt", "reclimit", "basecost", "rcost", "size", "ressize", "hp", "prot", "mr", "mor", "str", "att", "def", "prec", "enc", 
-			"mapmove", "ap", "ambidextrous", "mounted", "mountmnr", "skilledrider", "reinvigoration", "leader", "undeadleader", "magicleader", "startage", "maxage", "hand", "bow", "head", 
+			"mapmove", "ap", "ambidextrous", "mounted", "mountmnr", "mountgoldcost", "skilledrider", "reinvigoration", "leader", "leaderbonus", "undeadleader", "magicleader", "startage", "maxage", "hand", "bow", "head", 
 			"body", "foot", "misc", "crownonly", "pathcost", "startdom", "bonusspells", "F", "A", "W", "E", "S", "D", "N", "G", "B", "H", "rand1", "nbr1", "link1", "mask1", "rand2", 
 			"nbr2", "link2", "mask2", "rand3", "nbr3", "link3", "mask3", "rand4", "nbr4", "link4", "mask4", "holy", "inquisitor", "mind", "inanimate", 
 			"undead", "demon", "magicbeing", "stonebeing", "animal", "coldblood", "female", "forestsurvival", "mountainsurvival", "wastesurvival", 
@@ -91,7 +91,9 @@ public class MonsterStatIndexer extends AbstractStatIndexer {
 			"moreheat",	"moreluck", "moremagic", "nofmounts", "divinebeing", "falsedamagerecovery", "uwpathboost", "nofalldmg", "randomitems", "fireempower", 
 			"airempower", "waterempower", "earthempower", "popspy", "capitalhome", "deathslimeexpl", "deathpoisonexpl", "deathshockexpl", "drawsize", "clumsy", "petrificationimmune", 
 			"regainmount", "nobarding", "scarsouls", "spikebarbs", "pretenderstartsite", "mountiscom", "nothrowoff", "offscriptresearch", "bird", "decayres", 
-			"unmountedspr", "cubmother", "exhaustion", "glamour", "deadhp", "maxdeadhp", "verystupid", "deathdiseaseexpl", "end"}; 
+			"unmountedspr", "cubmother", "exhaustion", "glamour", "deadhp", "maxdeadhp", "verystupid", "deathdiseaseexpl",
+			"bravemount", "praise", "growthpower", "sleepres", "assencloc", "addupkeep", "deathgrab", "noremount", "noweapon", "labxpshape",
+			"icenatprot", "grandcom", "tolerateund", "faysummon", "3castbattlespell", "forcess", "command", "end"}; 
 			
 			
 	private static String values[][] = {{"heal", "mounted", "animal", "amphibian", "wastesurvival", "undead", "coldres15", "heat", "neednoteat", "fireres15", "poisonres15", "aquatic", "flying", "trample", "immobile", "immortal" },
@@ -103,6 +105,30 @@ public class MonsterStatIndexer extends AbstractStatIndexer {
 										{"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" }};
 	
 	private static String[][] KNOWN_MONSTER_ATTRS = {
+		{"0004", "bravemount"},
+		{"1A01", "praise"},
+		{"2701", "growthpower"},
+		{"4004", "sleepres"},
+		{"4704", "assencloc"},
+		{"4A04", "transformation"},
+		{"4D02", "addupkeep"},
+		{"4E04", "ainorec"},
+		{"5204", "commaster"},
+		{"5A04", "deathgrab"},
+		{"6404", "noremount"},
+		{"7004", "noweapon"},
+		{"7A04", "labxpshape"},
+		{"8504", "icenatprot"},
+		{"8804", "grandcom"},
+		{"8E04", "tolerateund"},
+		{"8F00", "summon5"},
+		{"8F04", "faysummon"},
+		{"9004", "3castbattlespell"},
+		{"9104", "forcess"},
+		{"9D00", "command"},
+		{"C601", "inspiringres"},
+		{"C701", "taxcollector"},
+		{"FD03", "mountgoldcost"},
 		{"F703", "mountmnr"},
 		{"4904", "skilledrider"},
 		{"F303", "truesight"},
@@ -692,12 +718,12 @@ public class MonsterStatIndexer extends AbstractStatIndexer {
 							monRandomMagic.link = value;
 							monRandomMagic.rand = 100;
 						} else if (path == 52) {
-							monRandomMagic.mask = 30720;
+							monRandomMagic.mask = 47104; // Sorcery: S D N B
 							monRandomMagic.nbr = 1;
 							monRandomMagic.link = value;
 							monRandomMagic.rand = 100;
 						} else if (path == 53) {
-							monRandomMagic.mask = 32640;
+							monRandomMagic.mask = 49024; // All: every path except Glamour
 							monRandomMagic.nbr = 1;
 							monRandomMagic.link = value;
 							monRandomMagic.rand = 100;
@@ -1032,6 +1058,10 @@ public class MonsterStatIndexer extends AbstractStatIndexer {
 					additionalLeader = monster.getAttribute("additional leadership").toString();
 				}
 				monster.addAttribute(new Attr("leader", 50+Integer.parseInt(additionalLeader)));
+				if (!"0".equals(additionalLeader) && !"".equals(additionalLeader)) {
+					// #command bonus on its own, "leader" above already includes it
+					monster.addAttribute(new Attr("leaderbonus", additionalLeader));
+				}
 				if (largeBitmap.contains("noleader")) {
 					if (!"".equals(additionalLeader)) {
 						monster.addAttribute(new Attr("leader", additionalLeader));

--- a/src/dom6utils/NametypeIndexer.java
+++ b/src/dom6utils/NametypeIndexer.java
@@ -30,7 +30,7 @@ public class NametypeIndexer {
 	public static void run() {
 		FileInputStream stream = null;
 		try {
-			stream = new FileInputStream("Dominions6.exe");
+			stream = new FileInputStream(AbstractStatIndexer.EXE_NAME);
 			
 			InputStreamReader isr = new InputStreamReader(stream, "ISO-8859-1");
 	        Reader in = new BufferedReader(isr);
@@ -61,7 +61,7 @@ public class NametypeIndexer {
 			
 			in.close();
 			
-			stream = new FileInputStream("Dominions6.exe");
+			stream = new FileInputStream(AbstractStatIndexer.EXE_NAME);
 			
 			isr = new InputStreamReader(stream, "ISO-8859-1");
 	        in = new BufferedReader(isr);

--- a/src/dom6utils/SiteStatIndexer.java
+++ b/src/dom6utils/SiteStatIndexer.java
@@ -423,7 +423,12 @@ public class SiteStatIndexer extends AbstractStatIndexer {
 					site.parameters.put("n_sum4", summon.sum4count);
 				}
 
-				siteList.add(site);
+				// Rarity 6 is not a value the modding manual knows (0, 1, 2, 5, 11-13). Only
+				// the unused padding records carry it: "The Empty Slot" and the "..." slot.
+				// Skip them but keep counting so the ids stay right.
+				if (rarity != 6) {
+					siteList.add(site);
+				}
 
 				stream = new FileInputStream(EXE_NAME);		
 				startIndex = startIndex + Starts.SITE_SIZE;

--- a/src/dom6utils/SpellDescDumper.java
+++ b/src/dom6utils/SpellDescDumper.java
@@ -32,7 +32,7 @@ public class SpellDescDumper {
 	public static void run() {		
 		FileInputStream stream = null;
 		try {
-			stream = new FileInputStream("Dominions6.exe");
+			stream = new FileInputStream(AbstractStatIndexer.EXE_NAME);
 			stream.skip(Starts.SPELL_DESC_INDEX);
 
 			List<Long> indexes = new ArrayList<Long>();
@@ -66,11 +66,11 @@ public class SpellDescDumper {
 			
 			for (Long offset : indexes) {
 				StringBuffer buffer = new StringBuffer();
-				stream = new FileInputStream("Dominions6.exe");
+				stream = new FileInputStream(AbstractStatIndexer.EXE_NAME);
 				stream.skip(offset-Starts.DESC_OFFSET);
 				while (stream.read(b) != -1) {
 					if (b[0] != 0) {
-						buffer.append(new String(new byte[] {b[0]}));
+						buffer.append(new String(new byte[] {b[0]}, java.nio.charset.StandardCharsets.ISO_8859_1));
 					} else {
 						break;
 					}
@@ -93,7 +93,7 @@ public class SpellDescDumper {
 					for (String name : names) {
 						Path path = Paths.get("spells", name.replaceAll("[^a-zA-Z0-9\\-]", "") + ".txt");
 						OutputStream os = Files.newOutputStream(path);
-						os.write(desc.getBytes());
+						os.write(desc.getBytes(java.nio.charset.StandardCharsets.ISO_8859_1));
 						os.close();
 					}
 					names.clear();

--- a/src/dom6utils/Starts.java
+++ b/src/dom6utils/Starts.java
@@ -16,23 +16,23 @@ package dom6utils;
  */
 
 public class Starts {
-	public static final long ITEM = 0x0318a320l;
+	public static final long ITEM = 0x0318cb40L;
 	public static final long ITEM_SIZE = 528l;
 	public static final long ITEM_ATTRIBUTE_OFFSET = 120l;
 	public static final long ITEM_BITMAP_START = 504l;
 	
-	public static final long MONSTER = 0x032eb658l;
+	public static final long MONSTER = 0x032ee018L;
 	public static final long MONSTER_SIZE = 888l;
 	public static final long MONSTER_ATTRIBUTE_OFFSET = 64l;
 	public static final long MONSTER_BITMAP_START = 872l;
 	
-	public static final long MONSTER_MAGIC = 0x047436e0l;
+	public static final long MONSTER_MAGIC = 0x04747090L;
 	
 	public static final long MONSTER_TRS_INDEX = 0x0001f92cl;
 	
 	public static final long ITEM_TRS_INDEX = 0x00002d0cl;
 
-	public static final long SITE = 0x043efd18l;
+	public static final long SITE = 0x043f36c8L;
 	public static final long SITE_SIZE = 312l;
 	public static final long SITE_ATTRIBUTE_OFFSET = 48;
 	
@@ -40,32 +40,32 @@ public class Starts {
 	public static final long FIXED_NAMES = 0x0113bb68l;
 	public static final int NAMES_COUNT = 161;
 	
-	public static final long SPELL = 0x045208e0l;
+	public static final long SPELL = 0x04524290L;
 	public static final long SPELL_ATTRIBUTE_OFFSET = 100l;
 	public static final long SPELL_ATTRIBUTE_GAP = 60l;
 	public static final long SPELL_SIZE = 280l;
 
-	public static final long DESC_OFFSET = 0x140001e00l;
-	public static final long ITEM_AND_MONSTER_DESC_INDEX = 0x00512930l;
-	public static final long SPELL_DESC_INDEX = 0x004f31d0l;
+	public static final long DESC_OFFSET = 0x140001000L;
+	public static final long ITEM_AND_MONSTER_DESC_INDEX = 0x00515c90L;
+	public static final long SPELL_DESC_INDEX = 0x004f64b0L;
 
-	public static final long EVENT = 0x00635d20l;
+	public static final long EVENT = 0x00637c60L;
 	public static final long EVENT_REQUIREMENT_OFFSET = 2408l;
 	public static final long EVENT_EFFECT_OFFSET = 2600l;
 	public static final long EVENT_SIZE = 2920l;
 	
-	public static final long MERCENARY = 0x032ad4f0l;
+	public static final long MERCENARY = 0x032afdd0L;
 	public static final long MERCENARY_SIZE = 312l;
 
-	public static final long ARMOR = 0x0037eaa8l;
+	public static final long ARMOR = 0x00380938L;
 	public static final long ARMOR_ATTRIBUTE_OFFSET = 72l;
 	public static final long ARMOR_SIZE = 104l;
 
-	public static final long WEAPON = 0x047a10d8l;
+	public static final long WEAPON = 0x047a4a68L;
 	public static final long WEAPON_ATTRIBUTE_OFFSET = 96l;
 	public static final long WEAPON_SIZE = 152l;
 	
-	public static final long NATION = 0x02f1fec0l;
+	public static final long NATION = 0x02f22080L;
 	public static final long NATION_ATTRIBUTE_OFFSET = 176l;
 	public static final long NATION_ATTRIBUTE_VALUE_OFFSET = 976l;
 	public static final long NATION_TROOP_OFFSET = 2576l;


### PR DESCRIPTION
- Updated offsets in Starts.java
- Added more requirement and effect codes to EventStatIndexer
- Added new monster stat attributes; random magic codes 52 and 53 now use the Dominions 6 path masks
- Site indexer will skip the rarity 6 padding records that 6.36 added
- Reads and writes are pinned to ISO-8859-1 instead of the JVM default, number formatting is pinned to Locale.US, and CSV cells in Latin-1 are re-encoded so the output is valid UTF-8
- The exe path can be set with the DOM6_EXE environment variable